### PR TITLE
Allow gzipped files for Illumina

### DIFF
--- a/bin/dehost.py
+++ b/bin/dehost.py
@@ -105,11 +105,16 @@ def main():
 
     generate_dehosted_output(read_list, header, args.output)
 
+    if len(read_list) == 0:
+        percentage_kept = 0
+    else:
+        percentage_kept = len(read_list)/(human_filtered_count + poor_quality_count + len(read_list)) * 100
+
     line = {    'sample' : sample_name,
                 'human_reads_filtered' : human_filtered_count, 
                 'poor_quality_reads_filtered' : poor_quality_count,
                 'paired_reads_kept' : len(read_list),
-                'total_read_pairs_checked' : human_filtered_count + poor_quality_count + len(read_list)}
+                'percentage_kept' : "{:.2f}".format(percentage_kept)}
 
     with open('{}_stats.csv'.format(sample_name), 'w') as csvfile:
         header = line.keys()

--- a/conf/illumina.config
+++ b/conf/illumina.config
@@ -24,16 +24,19 @@ params {
 
     // illumina fastq search path
     illuminaSuffixes = ['*_R{1,2}_001', '*_R{1,2}', '*_{1,2}', '*pair{1,2}' ]
+    fastqExtensions = ['.fastq', '.fastq.gz', '.fq', '.fq.gz']
 
-    fastqpaths = makeFastqPaths( params.illuminaSuffixes )
+    fastqpaths = makeFastqPaths( params.illuminaSuffixes, params.fastqExtensions )
 
 }
 
-def makeFastqPaths ( illuminaSuffixes ) {
+def makeFastqPaths ( illuminaSuffixes, fastqExtensions ) {
 
     def fastq_searchpath = []
     for (suffix in illuminaSuffixes){
-        fastq_searchpath.add(params.directory.toString() + '/**' + suffix.toString() + '.fastq')
+        for (extension in fastqExtensions){
+            fastq_searchpath.add(params.directory.toString() + '/**' + suffix.toString() + extension.toString())
+        }
     }
     return fastq_searchpath
 }

--- a/main.nf
+++ b/main.nf
@@ -53,9 +53,9 @@ workflow {
             System.exit(1)
 
         } else {
-            Channel.fromFilePairs( params.fastqpaths, flat: true)
+            Channel.fromFilePairs( params.fastqpaths, flat: true, maxDepth: 1)
                         .set{ ch_fastqs }
-            
+
             illuminaDehosting(ch_fastqs, ch_HumanReference, ch_CovidReference)
         }
     


### PR DESCRIPTION
Addresses #2 

Changes output qc to show a percentage of reads kept compared to the previous total reads looked at