### PR TITLE
Small performance improvement to dehost.py, output fastqs as gzipped

### DIFF
--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -101,7 +101,7 @@ process dehostBamFiles {
 
 process generateDehostedReads {
 
-    publishDir "${params.outdir}/dehosted_paired_fastqs", pattern: "${sampleName}-dehosted_R*", mode: "copy"
+    publishDir "${params.outdir}/dehosted_fastqs", pattern: "${sampleName}-dehosted_R*", mode: "copy"
 
     label 'mediumcpu'
 
@@ -113,7 +113,7 @@ process generateDehostedReads {
 
     script:
     """
-    samtools fastq -1 ${sampleName}-dehosted_R1.fastq -2 ${sampleName}-dehosted_R2.fastq ${dehosted_bam}
+    samtools fastq -1 ${sampleName}-dehosted_R1.fastq.gz -2 ${sampleName}-dehosted_R2.fastq.gz ${dehosted_bam}
     """
 }
 


### PR DESCRIPTION
Through testing on my one of > 300 million reads set it seems to have raised the potential Kraken2 variants from 172 to 507

I'd have to check how the reads actually map to see if that is ok. For now this will be a wait incase we need the speed-up