### PR TITLE
Fix header name for nanopore removal summary file and remove empty fastqs

### DIFF
--- a/bin/dehost_nanopore.py
+++ b/bin/dehost_nanopore.py
@@ -97,7 +97,7 @@ def main():
     line = {    'sample' : sample_name,
                 'human_reads_filtered' : h_count, 
                 'poor_quality_reads_filtered' : p_count,
-                'paired_reads_kept' : len(keep_read_list),
+                'reads_kept' : len(keep_read_list),
                 'percentage_kept' : "{:.2f}".format(percentage_kept),
                 'github_commit' : args.revision
             }

--- a/conf/nanopore.config
+++ b/conf/nanopore.config
@@ -54,5 +54,8 @@ if ( params.nanostripper ) {
 
         // Generate dehosted fast5 files ONLY if a barcoded directory is given as fastq input
         fast5_directory = false
+        
+        // Filter out reads of a specific count before fast5 generation
+        min_read_count = 1
     }
 }

--- a/conf/resources.config
+++ b/conf/resources.config
@@ -1,7 +1,7 @@
 // Cores
 params {
     illumina_threads = 2
-    nanopore_threads = 3
+    nanopore_threads = 2
 }
 
 process {
@@ -40,8 +40,8 @@ process {
     }
 
     withLabel: regenerateFast5s {
-        cpus = 3
-        memory = 16.GB
+        cpus = 2
+        memory = 12.GB
     }
 
     // CPU and Memory Allocation for Specific Processes

--- a/workflows/nanopore_dehosting.nf
+++ b/workflows/nanopore_dehosting.nf
@@ -129,7 +129,7 @@ workflow nanoporeMinimap2Dehosting {
       Channel.fromPath( "${params.fast5_directory}")
                         .set{ ch_Fast5 }
       regenerateFast5s_MM2(regenerateFastqFiles.out
-                                         .filter{ it[1].countFastq() > 5}
+                                         .filter{ it[1].countFastq() >= params.min_read_count }
                                          .combine(ch_Fast5))
       generateSimpleSequencingSummary(regenerateFast5s_MM2.out.collect())
     }

--- a/workflows/nanopore_dehosting.nf
+++ b/workflows/nanopore_dehosting.nf
@@ -129,6 +129,7 @@ workflow nanoporeMinimap2Dehosting {
       Channel.fromPath( "${params.fast5_directory}")
                         .set{ ch_Fast5 }
       regenerateFast5s_MM2(regenerateFastqFiles.out
+                                         .filter{ it[1].countFastq() > 5}
                                          .combine(ch_Fast5))
       generateSimpleSequencingSummary(regenerateFast5s_MM2.out.collect())
     }


### PR DESCRIPTION
Fixing 2 issues along with updating the documentation.

1. Basic copy and paste error for the header line that was missed (was paired_fastq, now just fastq)
2. Address #17 