### PR TITLE
Add flat fastq output parameter for nanopore-minimap2 pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,9 @@ Other arguments include:
 | run_name | Specify output run name to separate results | None | No |
 | min_length | Minimum fastq read length to keep | 400 | Yes |
 | max_length | Maximum fastq read length to keep | 2400 | Yes |
+| min_read_count | Minimum read count required to output results | 1 | Yes
 | fast5_directory | Directory of run associated fast5 files to be dehosted | None | Yes |
-| min_read_count  | Minimum read count required to do fast5 regeneration | 1 | Yes
+| flat | Output flat fastq_pass folder instead of sample name subdirectories (better for folder input of named files) | None | Yes
 
 #### **Running**
 
@@ -278,13 +279,20 @@ Full instructions on how to easily install and run the Nanopore Minimap2 fastq d
 
 Found in `./results/<run_name>/run/` directory, the outputs for the Nanopore pipeline include:
 
-- fastq_pass --> Folder containing the finished dehosted fastq files that can be used for another analysis (separated by either barcode## or sample name)
+- fastq_pass --> Folder containing the finished dehosted fastq files that pass the minimum read check (default: 1) which can be used for any other analyses
+    - Separated by either barcode## or sample name depending upon input fastq folder structure
+    - If `--flat` is passed, all fastq files will be in the main `fastq_pass` directory instead of named subdirectories.
 
-- fast5_pass --> Folder containing the finished dehosted fast5 files that can be used to run another analysis (separated by either barcode## or sample name). Only if --fast5_directory is given.
+- fast5_pass --> Folder containing the finished dehosted fast5 files that can be used for any other analyses
+    - Separated by either barcode## or sample name depending upon input fastq folder structure
+    - Only if --fast5_directory flag is passed
 
-- sequencing_summary --> Simplified dehosted sequencing summary output only containing the read name and its specific fast5 file to allow data to be re-ran. Only if --fast5_directory is given
+- sequencing_summary --> Simplified dehosted sequencing summary output only containing the read name and its specific fast5 file to allow data to be re-ran.
+    - Only if --fast5_directory flag is passed
 
 - removal_summary --> CSV file containing read removal metrics. Found in `./results/<run_name>/` instead
+    - Shows the number and percentage of reads kept
+    - Shows if the sample failed the minimum read filter
 
 The output structure is setup as such so that the `run_name` organizes the sequencing data in the `run` folder and all analyses can be done in the `run_name` folder to separate out runs better.
 

--- a/bin/dehost_nanopore.py
+++ b/bin/dehost_nanopore.py
@@ -15,6 +15,7 @@ def init_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument('-f', '--file', required=True, help='Composite Reference BAM file of mapped reads')
     parser.add_argument('-k', '--keep_id', required=False, default='MN908947.3', type=str, help='Reference ID of genome to keep. Default: MN908947.3')
+    parser.add_argument('-m', '--min_reads', required=False, default=1, type=int, help='Minimum number of reads required to generate dehosted BAM file')
     parser.add_argument('-q', '--keep_minimum_quality', required=False, type=int, default=60, help='Minimum quality of the reads to keep. Default: 60')
     parser.add_argument('-Q', '--remove_minimum_quality', required=False, type=int, default=10, help='Minimum quality of the reads to be included in removal. Default: 10')
     parser.add_argument('-o', '--output', required=False, default='out.bam', help='Output BAM name')
@@ -86,7 +87,11 @@ def main():
 
     # Keep reads based on input contig ID and mapping qualities given and then generate the output bam file using input files header with pysam
     keep_read_list, h_count, p_count, header = keep_reads_by_contig_id(args.file, args.keep_id, args.remove_minimum_quality, args.keep_minimum_quality)
-    generate_dehosted_output(keep_read_list, header, args.output)
+    if len(keep_read_list) >= args.min_reads:
+        generate_dehosted_output(keep_read_list, header, args.output)
+        output_generated = True
+    else:
+        output_generated = False
 
     # Set up the output CSV file for tracking
     if len(keep_read_list) == 0:
@@ -99,6 +104,7 @@ def main():
                 'poor_quality_reads_filtered' : p_count,
                 'reads_kept' : len(keep_read_list),
                 'percentage_kept' : "{:.2f}".format(percentage_kept),
+                'meets_count_filter' : output_generated,
                 'github_commit' : args.revision
             }
 

--- a/conf/custom/nml.config
+++ b/conf/custom/nml.config
@@ -41,9 +41,9 @@ process {
     }
 
     withLabel: regenerateFast5s {
-        clusterOptions = "--partition=OutbreakResponse -c 16 --mem=48G"
+        clusterOptions = "--partition=OutbreakResponse -c 16 --mem=64G"
         cpus = 16
-        memory = 48.GB
+        memory = 64.GB
     }
 
     // CPU and Memory Allocation for Specific Processes

--- a/conf/nanopore.config
+++ b/conf/nanopore.config
@@ -57,5 +57,8 @@ if ( params.nanostripper ) {
         
         // Filter out reads of a specific count before fast5 generation
         min_read_count = 1
+
+        // Output data into flat directory instead of to folders
+        flat = false
     }
 }

--- a/modules/help.nf
+++ b/modules/help.nf
@@ -57,15 +57,20 @@ def helpStatement() {
     Minimap2 Pipeline Arguments:
         Mandatory:
             --fastq_directory [path]            Path to directory containing either barcoded directories OR individual fastq files
+            --run_name [str]                    Seperate results based on a run name input
 
         Optional:
             --fast5_directory [path]            Path to fast5 directories associated with the data
             --composite_minimap2_index [file]   Path to composite minimap2 .mmi file to speed up analysis
+            --flat                              Flag to flatten fastq output from named dirs to flat files in output fastq_pass dir
             --min_length [i]                    Minimum length of fastq reads to keep (Default: 400)
             --max_length [i]                    Maximum length of fastq reads to keep (Default: 2400)
+            --min_read_count [i]                Minimum read count required to output results (Default: 1)
 
         Example Command:
-            nextflow run phac-nml/ncov-dehoster --human_ref ./hg38.fa -profile conda --nanopore --minimap2 --fastq_directory ./fastqs
+            nextflow run phac-nml/ncov-dehoster --human_ref ./hg38.fa -profile conda --nanopore --minimap2
+                --fastq_directory ./fastqs 
+                --run_name 'example_run_name'
       
   """.stripIndent()
 }

--- a/modules/nanopore_minimap2.nf
+++ b/modules/nanopore_minimap2.nf
@@ -71,7 +71,7 @@ process removeHumanReads {
     tuple val(sampleName), path(sorted_bam)
 
     output:
-    tuple val(sampleName), path("${sampleName}.host_removed.sorted.bam"), emit: bam
+    tuple val(sampleName), path("${sampleName}.host_removed.sorted.bam"), optional: true, emit: bam
     path "${sampleName}*.csv", emit: csv
 
     script:
@@ -80,7 +80,7 @@ process removeHumanReads {
 
     """
     samtools index $sorted_bam
-    dehost_nanopore.py --file $sorted_bam --output ${sampleName}.host_removed.sorted.bam --revision ${rev}
+    dehost_nanopore.py --file $sorted_bam --min_reads ${params.min_read_count} --output ${sampleName}.host_removed.sorted.bam --revision ${rev}
     """
 }
 

--- a/modules/nanopore_minimap2.nf
+++ b/modules/nanopore_minimap2.nf
@@ -102,6 +102,24 @@ process regenerateFastqFiles {
     """
 }
 
+process regenerateFastqFilesFlat {
+    publishDir "${params.outdir}/${params.run_name}/run/fastq_pass/", pattern: "*.host_removed.fastq", mode: "copy"
+
+    label 'smallCPU'
+    tag { sampleName }
+
+    input:
+    tuple val(sampleName), path(dehosted_bam)
+
+    output:
+    tuple val(sampleName), file("${sampleName}.host_removed.fastq")
+
+    script:
+    """
+    samtools fastq $dehosted_bam > ${sampleName}.host_removed.fastq
+    """
+}
+
 process regenerateFast5s_MM2 {
     publishDir "${params.outdir}/${params.run_name}/run", pattern: "fast5_pass/${sampleName}", mode: "copy"
 


### PR DESCRIPTION
## Changes
- Added `--flat` param that addresses #19 mostly
  - It does not address the fast5 files (they stay split by sample) but this should not mess with pipelines
-  Added more memory for NML fast5 output process as it was having problems on some datasets
-  Addressed #20 so that files failing the min_read_count are no longer output
- Update to README and help statements for --flat and --min_read_count