### PR TITLE
Add openblas threads as env variable to allow large datasets to run

### DIFF
--- a/conf/custom/nml.config
+++ b/conf/custom/nml.config
@@ -4,6 +4,10 @@ params {
     nanopore_threads = 16
 }
 
+env {
+    OPENBLAS_NUM_THREADS = 32
+}
+
 process {
     // Base processes computational parameters
     executor = "slurm"

--- a/conf/custom/nml.config
+++ b/conf/custom/nml.config
@@ -5,7 +5,7 @@ params {
 }
 
 env {
-    OPENBLAS_NUM_THREADS = 32
+    OPENBLAS_NUM_THREADS = 12
 }
 
 process {


### PR DESCRIPTION
Issues stemming from running large datasets where we were hitting the `max user processes` limit (ulimit -u 4096 is the default) caused pipeline to crash.

Setting the limit to 32 threads/process and 100 max processes keeps us under that