### PR TITLE
Allow greater options in nanopore host removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Argument Changes:
 Parameter Changes:
 - Default minimum read length for nanopore data (`--min_length`) set to 350 from 400 to better accommodate shorter amplicon schemes
 
+General Developer Changes:
+- Changed code order for nanopore workflows
+    - All minimap2 code should be above nanostripper in the files now
+- General reformatting of code to try to make everything more consistent/cohesive
+
 
 ## Version 0.1.0
 ----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,23 @@ Argument Changes:
     - Allows for a different reference ID to be kept if the reference sequence is changed
 - Removed `--covid_ref_id <ID>` as an illumina specific argument
     - Replaced by above
+- Removed the `illumina_threads` and `nanopore_threads` resource arguments that were not super useful
+    - Changed to using `task.cpus` to keep everything in line
+    - Resources should be changed using the process name or the process tag now
 
 Parameter Changes:
 - Default minimum read length for nanopore data (`--min_length`) set to 350 from 400 to better accommodate shorter amplicon schemes
+- Help command updated
+
+Output Changes:
+- New output file: `process_versions.yml`
+    - File contains process name along with tools and their versions used in it
 
 General Developer Changes:
 - Changed code order for nanopore workflows
     - All minimap2 code should be above nanostripper in the files now
 - General reformatting of code to try to make everything more consistent/cohesive
-
+- Moved the minimap2 workflow above the nanostripper workflow in all processes
 
 ## Version 0.1.0
 ----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Version 0.2.0
+----------------
+Argument Changes:
+- Added `--keep_ref_id <ID>` as an argument for illumina and nanopore fastq data
+    - Allows for a different reference ID to be kept if the reference sequence is changed
+- Removed `--covid_ref_id <ID>` as an illumina specific argument
+    - Replaced by above
+
+Parameter Changes:
+- Default minimum read length for nanopore data (`--min_length`) set to 350 from 400 to better accommodate shorter amplicon schemes
+
+
 ## Version 0.1.0
 ----------------
 Argument Changes:

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ## About:
 Nextflow pipeline that removes human reads from SARS-CoV-2 Illumina or Nanopore sequencing data. Basic details for the three available pipelines are as follows:
 
-**Illumina Paired Pipeline \(v0.1.0)** - Competitive mapping approach using [bwa mem](http://bio-bwa.sourceforge.net/bwa.shtml) to remove human reads from input fastq file pairs while maintaining as many viral reads as possible.
+**Illumina Paired Pipeline \(v0.2.0)** - Competitive mapping approach using [bwa mem](http://bio-bwa.sourceforge.net/bwa.shtml) to remove human reads from input fastq file pairs while maintaining as many viral reads as possible.
 
-**Nanopore Minimap2 Fastq Pipeline \(v0.1.0)** - Competitive mapping approach using [minimap2](https://github.com/lh3/minimap2) to remove human reads from either input fastq files or barcoded fastq directories while maintaining as many viral reads as possible. 
+**Nanopore Minimap2 Fastq Pipeline \(v0.2.0)** - Competitive mapping approach using [minimap2](https://github.com/lh3/minimap2) to remove human reads from either input fastq files or barcoded fastq directories while maintaining as many viral reads as possible. 
 - Strict demultiplexing is *highly recommended* before running (unable to do so after and it improves downstream analyses)
 - Optional fast5 dehosting available with argument `--fast5_directory [dir]`
 
@@ -45,7 +45,10 @@ Nextflow pipeline that removes human reads from SARS-CoV-2 Illumina or Nanopore 
 
 ------
 
-## Changelog
+## Changelog Highlights
+
+#### Release v0.2.0
+- Better user parameter options
 
 #### Release v0.1.0
 - Initial release

--- a/README.md
+++ b/README.md
@@ -128,12 +128,12 @@ Minimum computational specs required for the minimap2 nanopore fastq host remova
 Run the full *Nanopore Nanostripper* pipeline with the following command:
 
 ```
-nextflow run phac-nml/ncov-dehoster -profile conda --nanopore --nanostripper --fast5_directory <path/to/fast5_pass/> --human_ref <path/to/reference> --run_name 'whatever_you_want' --guppyCPU </path/to/conda_env/guppy-4.0.11-cpu/>
+nextflow run phac-nml/ncov-dehoster -profile conda --nanopore --nanostripper --fast5_directory <path/to/fast5_pass/> --human_ref <path/to/reference> --run_name 'whatever_you_want' --guppyCPU </path/to/conda_env/guppy-cpu/> --guppyGPU </path/to/conda_env/guppy-gpu/>
 ```
 
 You can also just generate dehosted fast5 files with nanostripper with no guppy environment specified. Guppy is proprietary software of ONT Technologies so you must create your own environment for it
 
-Minimum computational specs required for the Nanopore dehosting pipeline are 16+ cpu and 68+G memory. GPU highly recommended to run or it will take >12 hours.
+Minimum computational specs required for the Nanopore dehosting pipeline are 16+ cpu and 68+G memory. Configuring a GPU is highly recommended to run basecalling or the pipeline will take >12 hours to run the basecalling step (with a GPU it will be about 1-4 hours).
 
 ------
 
@@ -325,7 +325,7 @@ Full instructions on how to easily install and run the Nanopore Minimap2 fastq d
     - Demultiplex the data using [guppy_barcoder](https://community.nanoporetech.com) (proprietary from ONT) and the `--require_barcodes_both_ends` flag to make sure that barcodes are present on each end of the reads.
         - There are some spots in the genome where this helps in resolution when analyzing the data
     
-    - **Note** that the output fastq files are not able to be demultiplexed anymore
+    - **Note** that the output fastq files are not able to be demultiplexed anymore so if you wish to strictly demultiplex the data it is advised to do it before running this host-removal pipeline.
         - May be able to be fixed in a later version
 
 3. Ensure nextflow is available and then run the pipeline
@@ -624,7 +624,7 @@ The output structure is setup as such so that the `run_name` organizes the seque
 
 Profiles are a set of configuration attributes that can be activated (as many as you want as long as they are comma separated) when launching a pipeline. More information can be found [here](https://www.nextflow.io/docs/latest/config.html?highlight=profile#config-profiles)
 
-If no profile is given, the Illumina pipeline will still function correctly and will run locally so long as the system has all of the dependencies installed and meets the computational requirements for the processes. The nanopore pipeline currently requires a guppy conda environment to re-basecall and demultiplex the fast5 files
+If no profile is given, the Illumina and nanopore minimap2 pipelines will still function correctly and will run all processes locally so long as the system has all of the dependencies installed and meets the computational requirements. The nanopore nanostripper pipeline currently requires a guppy conda environment to re-basecall and demultiplex the fast5 files.
 
 Profiles can be activated with `-profile <profile_name>`. Below are the profiles currently available with this pipeline
 

--- a/conf/custom/nml.config
+++ b/conf/custom/nml.config
@@ -1,13 +1,9 @@
-// Cores
-params {
-    illumina_threads = 4
-    nanopore_threads = 16
-}
-
+// Set needed environment variables - below fixes issue we had with openblas on cluster
 env {
     OPENBLAS_NUM_THREADS = 12
 }
 
+// Process Specs and Error Handling
 process {
     // Base processes computational parameters
     executor = "slurm"

--- a/conf/custom/test.config
+++ b/conf/custom/test.config
@@ -1,13 +1,9 @@
-// Cores
-params {
-    illumina_threads = 2
-    nanopore_threads = 2
-}
-
+// Set needed environment variables
 env {
     OPENBLAS_NUM_THREADS = 1
 }
 
+// Process Specs and Error Handling
 process {
     // Base processes computational parameters
     cpus = 1

--- a/conf/illumina.config
+++ b/conf/illumina.config
@@ -6,9 +6,6 @@ params {
     // Illumina fastq reads directory, can be singular or paired
     directory = false
 
-    // Covid Reference Contig ID
-    covid_ref_id = "MN908947.3"
-
     // Composite bwa index folder (so that they don't have to be made each time)
     composite_bwa_index = false
 

--- a/conf/nanopore.config
+++ b/conf/nanopore.config
@@ -1,6 +1,5 @@
 // Nanopore General Parameters
 params {
-
     // Run name -- Seperate results based on a run name
     run_name = false
 
@@ -10,8 +9,30 @@ params {
     // Maximum fastq read length
     max_length = 2400
 }
+// Minimap2
+if ( params.minimap2 ) {
+    params {
+        //### Required ###//
+
+        // Directory containing fastq files OR directory containing barcode directories
+        fastq_directory = false
+
+        //### Optional ###//
+
+        // Composite Human and Covid minimap2 index to speed up mapping (generated if not given)
+        composite_minimap2_index = false
+
+        // Generate dehosted fast5 files ONLY if a barcoded directory is given as fastq input
+        fast5_directory = false
+        
+        // Filter out reads of a specific count before fast5 generation
+        min_read_count = 1
+
+        // Output data into flat directory instead of to folders
+        flat = false
+    }
 // Nanostripper
-if ( params.nanostripper ) {
+} else {
     params {
         //### Required ###//
 
@@ -38,27 +59,5 @@ if ( params.nanostripper ) {
         guppyGPU = false
         gpu_per_node = 2
         max_parallel_basecalling = 6
-    }
-// Minimap2
-} else {
-    params {
-        //### Required ###//
-
-        // Directory containing fastq files OR directory containing barcode directories
-        fastq_directory = false
-
-        //### Optional ###//
-
-        // Composite Human and Covid minimap2 index to speed up mapping (generated if not given)
-        composite_minimap2_index = false
-
-        // Generate dehosted fast5 files ONLY if a barcoded directory is given as fastq input
-        fast5_directory = false
-        
-        // Filter out reads of a specific count before fast5 generation
-        min_read_count = 1
-
-        // Output data into flat directory instead of to folders
-        flat = false
     }
 }

--- a/conf/nanopore.config
+++ b/conf/nanopore.config
@@ -5,7 +5,7 @@ params {
     run_name = false
 
     // Minimum fastq read length
-    min_length = 400
+    min_length = 350
 
     // Maximum fastq read length
     max_length = 2400

--- a/conf/resources.config
+++ b/conf/resources.config
@@ -1,9 +1,4 @@
-// Cores
-params {
-    illumina_threads = 2
-    nanopore_threads = 2
-}
-
+// Process Specs and Error Handling
 process {
     // Base processes computational parameters
     cpus = 1

--- a/modules/help.nf
+++ b/modules/help.nf
@@ -12,6 +12,8 @@ def helpStatement() {
 
     Profiles:
         -profile [conda,nml]            Configuration profile to use. Can use both if separated by a comma
+            conda                         Utilize conda to control tool and dependency installation (uses mamba for environment install)
+            nml                           NML specific profile to take advantage of NML cluster resources
 
     Pick a Pipeline:
         --illumina                      Run Illumina BWA_MEM based competitive host removal pipeline on paired fastq files
@@ -24,7 +26,8 @@ def helpStatement() {
             --directory [path]          Path to directory containing paired fastq files to dehost
         
         Optional:
-            --composite_bwa_index [path]    Path to directory containing BWA indexed composite genome
+            --composite_bwa_index [path]    Path to directory containing BWA indexed composite genome (Note: still need human reference)
+            --keep_ref_id [str]             String name of reference contig ID to keep during host removal (Default: 'MN908947.3')
             --keep_min_map_quality [i]      Integer minimum mapping quality of COVID-19 reads to keep (Default: 60)
             --remove_min_map_quality [i]    Integer minimum mapping quality of HUMAN reads to remove (Default: 0)
 
@@ -42,7 +45,7 @@ def helpStatement() {
             --guppyGPU [path]               Path to guppy GPU conda environment to basecall
 
         Optional:
-            --min_length [i]                Minimum length of fastq reads to keep (Default: 400)
+            --min_length [i]                Minimum length of fastq reads to keep (Default: 350)
             --max_length [i]                Maximum length of fastq reads to keep (Default: 2400)
             --human_minimap2_index [file]   Path to minimap2 human indexed .mmi file to speed up analysis
 
@@ -62,6 +65,7 @@ def helpStatement() {
         Optional:
             --fast5_directory [path]            Path to fast5 directories associated with the data
             --composite_minimap2_index [file]   Path to composite minimap2 .mmi file to speed up analysis
+            --keep_ref_id [str]                 String name of reference contig ID to keep during host removal (Default: 'MN908947.3')
             --flat                              Flag to flatten fastq output from named dirs to flat files in output fastq_pass dir
             --min_length [i]                    Minimum length of fastq reads to keep (Default: 400)
             --max_length [i]                    Maximum length of fastq reads to keep (Default: 2400)

--- a/modules/help.nf
+++ b/modules/help.nf
@@ -18,15 +18,15 @@ def helpStatement() {
     Pick a Pipeline:
         --illumina                      Run Illumina BWA_MEM based competitive host removal pipeline on paired fastq files
         --nanopore                      Set Nanopore data as input, MUST pick a sub pipeline
-            --nanostripper                Run Nanopore host removal based on input fast5 files and nanostripper (NEEDS GUPPY INSTALLED)
             --minimap2                    Run Nanopore host removal based on input fastq files and minimap2
+            --nanostripper                Run Nanopore host removal based on input fast5 files, nanostripper, and guppy (NOT CURRENTLY MAINTAINED)
 
     Illumina Pipeline Arguments:
         Mandatory:
             --directory [path]          Path to directory containing paired fastq files to dehost
-        
+
         Optional:
-            --composite_bwa_index [path]    Path to directory containing BWA indexed composite genome (Note: still need human reference)
+            --composite_bwa_index [path]    Path to directory containing BWA indexed composite genome (Note: still need human reference fasta)
             --keep_ref_id [str]             String name of reference contig ID to keep during host removal (Default: 'MN908947.3')
             --keep_min_map_quality [i]      Integer minimum mapping quality of COVID-19 reads to keep (Default: 60)
             --remove_min_map_quality [i]    Integer minimum mapping quality of HUMAN reads to remove (Default: 0)
@@ -34,8 +34,32 @@ def helpStatement() {
         Example Command:
             nextflow run phac-nml/ncov-dehoster --human_ref ./hg38.fa -profile conda --illumina --directory ./paired_fastqs
 
+                                        ------------------------------------------
+
+    Minimap2 Pipeline Arguments:
+        Mandatory:
+            --fastq_directory [path]            Path to directory containing either barcoded directories OR individual fastq files
+            --run_name [str]                    Seperate results based on a run name input
+
+        Optional:
+            --fast5_directory [path]            Path to fast5 directories associated with the data
+            --composite_minimap2_index [file]   Path to composite minimap2 .mmi file to speed up analysis
+            --keep_ref_id [str]                 String name of reference contig ID to keep during host removal (Default: 'MN908947.3')
+            --min_length [i]                    Minimum length of fastq reads to keep (Default: 400)
+            --max_length [i]                    Maximum length of fastq reads to keep (Default: 2400)
+            --min_read_count [i]                Minimum read count required to output results (Default: 1)
+            --flat                              Flag to flatten fastq output from named dirs to flat files in the output fastq_pass dir
+                                                    See the README for an example of the output differences
+
+        Example Command:
+            nextflow run phac-nml/ncov-dehoster --human_ref ./hg38.fa -profile conda --nanopore --minimap2
+                --fastq_directory ./fastqs 
+                --run_name 'example_run_name'
+
+                                        ------------------------------------------
+
     Nanostripper Pipeline Arguments:
-      **NOTE: I DO NOT RECOMMEND RUNNING THIS PIPELINE AT THE MOMENT, USE THE MINIMAP2 ONE THAT FOLLOWS**
+      **NOTE: I DO NOT RECOMMEND RUNNING THIS PIPELINE AT THE MOMENT (NOT MAINTAINED), USE THE MINIMAP2 ONE ABOVE**
         Mandatory:
             --run_name [str]                Seperate results based on a run name input
             --fast5_directory [path]        Path to barcoded fast5 directories
@@ -56,25 +80,6 @@ def helpStatement() {
                 --nanostripper_env_path ./conda/nanostripper_env
                 --guppyCPU ./conda/guppyCPU_env/
                 --guppyGPU ./conda/guppyGPU_env/
-
-    Minimap2 Pipeline Arguments:
-        Mandatory:
-            --fastq_directory [path]            Path to directory containing either barcoded directories OR individual fastq files
-            --run_name [str]                    Seperate results based on a run name input
-
-        Optional:
-            --fast5_directory [path]            Path to fast5 directories associated with the data
-            --composite_minimap2_index [file]   Path to composite minimap2 .mmi file to speed up analysis
-            --keep_ref_id [str]                 String name of reference contig ID to keep during host removal (Default: 'MN908947.3')
-            --flat                              Flag to flatten fastq output from named dirs to flat files in output fastq_pass dir
-            --min_length [i]                    Minimum length of fastq reads to keep (Default: 400)
-            --max_length [i]                    Maximum length of fastq reads to keep (Default: 2400)
-            --min_read_count [i]                Minimum read count required to output results (Default: 1)
-
-        Example Command:
-            nextflow run phac-nml/ncov-dehoster --human_ref ./hg38.fa -profile conda --nanopore --minimap2
-                --fastq_directory ./fastqs 
-                --run_name 'example_run_name'
       
   """.stripIndent()
 }

--- a/modules/help.nf
+++ b/modules/help.nf
@@ -49,7 +49,6 @@ def helpStatement() {
             --max_length [i]                    Maximum length of fastq reads to keep (Default: 2400)
             --min_read_count [i]                Minimum read count required to output results (Default: 1)
             --flat                              Flag to flatten fastq output from named dirs to flat files in the output fastq_pass dir
-                                                    See the README for an example of the output differences
 
         Example Command:
             nextflow run phac-nml/ncov-dehoster --human_ref ./hg38.fa -profile conda --nanopore --minimap2

--- a/modules/help.nf
+++ b/modules/help.nf
@@ -45,7 +45,7 @@ def helpStatement() {
             --fast5_directory [path]            Path to fast5 directories associated with the data
             --composite_minimap2_index [file]   Path to composite minimap2 .mmi file to speed up analysis
             --keep_ref_id [str]                 String name of reference contig ID to keep during host removal (Default: 'MN908947.3')
-            --min_length [i]                    Minimum length of fastq reads to keep (Default: 400)
+            --min_length [i]                    Minimum length of fastq reads to keep (Default: 350)
             --max_length [i]                    Maximum length of fastq reads to keep (Default: 2400)
             --min_read_count [i]                Minimum read count required to output results (Default: 1)
             --flat                              Flag to flatten fastq output from named dirs to flat files in the output fastq_pass dir

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -38,11 +38,18 @@ process indexCompositeReference {
     path(composite_ref)
 
     output:
-    file("*.fa*")
+    file("*.fa*"), emit: index
+    path("*.process.yml"), emit: versions
 
     script:
     """
     bwa index -a bwtsw $composite_ref
+
+    # Versions #
+    cat <<-END_VERSIONS > indexbwa.process.yml
+        "${task.process}":
+            bwa: \$(echo \$(bwa 2> >(grep -o 'Version' | cut -d ' ' -f 2)))
+    END_VERSIONS
     """
 }
 
@@ -55,13 +62,21 @@ process compositeMappingBWA {
 
     output:
     tuple val(sampleName), path("${sampleName}.sorted.bam"), emit: bam
-    path("${sampleName}.flagstats.txt")
+    path("${sampleName}.flagstats.txt"), emit: flagstats
+    path("*.process.yml"), emit: versions
 
     script:
     processThreads = task.cpus * 2
     """
     bwa mem -t ${processThreads} ${composite_reference} ${forward} ${reverse} | samtools sort --threads ${task.cpus} -T "temp" -O BAM -o ${sampleName}.sorted.bam
     samtools flagstat ${sampleName}.sorted.bam > ${sampleName}.flagstats.txt
+
+    # Versions #
+    cat <<-END_VERSIONS > mapbwa.process.yml
+        "${task.process}":
+            bwa: \$(echo \$(bwa 2> >(grep -o 'Version' | cut -d ' ' -f 2)))
+            samtools: \$(echo \$(samtools --version | head -n 1 | grep samtools | sed 's/samtools //'))
+    END_VERSIONS
     """
 }
 
@@ -77,6 +92,7 @@ process dehostBamFiles {
     output:
     tuple val(sampleName), path("${sampleName}.dehosted.bam"), emit: bam
     path "${sampleName}*.csv", emit: csv
+    path("*.process.yml"), emit: versions
 
     script:
 
@@ -90,6 +106,13 @@ process dehostBamFiles {
     -Q ${params.remove_min_map_quality} \
     -o ${sampleName}.dehosted.bam \
     -R ${rev} 
+
+    # Versions #
+    cat <<-END_VERSIONS > dehostbam.process.yml
+        "${task.process}":
+            samtools: \$(echo \$(samtools --version | head -n 1 | grep samtools | sed 's/samtools //'))
+            dehost_illumina.py: 0.1.0
+    END_VERSIONS
     """
 }
 
@@ -103,11 +126,18 @@ process generateDehostedReads {
     tuple( val(sampleName), path(dehosted_bam))
 
     output:
-    path("${sampleName}_dehosted_R*")
+    path("${sampleName}_dehosted_R*"), emit: dehosted_fastq
+    path("*.process.yml"), emit: versions
 
     script:
     """
     samtools fastq -1 ${sampleName}_dehosted_R1.fastq.gz -2 ${sampleName}_dehosted_R2.fastq.gz ${dehosted_bam}
+
+    # Versions #
+    cat <<-END_VERSIONS > index.process.yml
+        "${task.process}":
+            samtools: \$(echo \$(samtools --version | head -n 1 | grep samtools | sed 's/samtools //'))
+    END_VERSIONS
     """
 }
 
@@ -120,10 +150,17 @@ process combineCSVs {
     path(csvs)
 
     output:
-    path("removal_summary.csv")
+    path("removal_summary.csv"), emit: summary
+    path("*.process.yml"), emit: versions
 
     script:
     """
     csvtk concat *_stats.csv > removal_summary.csv
+
+    # Versions #
+    cat <<-END_VERSIONS > csv.process.yml
+        "${task.process}":
+            csvtk: \$(echo \$(csvtk version | sed 's/csvtk //'))
+    END_VERSIONS
     """
 }

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -38,7 +38,7 @@ process indexCompositeReference {
     path(composite_ref)
 
     output:
-    file("*.fa*"), emit: index
+    path("*.fa*"), emit: index
     path("*.process.yml"), emit: versions
 
     script:

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -58,8 +58,9 @@ process compositeMappingBWA {
     path("${sampleName}.flagstats.txt")
 
     script:
+    processThreads = task.cpus * 2
     """
-    bwa mem -t ${params.illumina_threads} ${composite_reference} ${forward} ${reverse} | samtools sort --threads ${params.illumina_threads} -T "temp" -O BAM -o ${sampleName}.sorted.bam
+    bwa mem -t ${processThreads} ${composite_reference} ${forward} ${reverse} | samtools sort --threads ${task.cpus} -T "temp" -O BAM -o ${sampleName}.sorted.bam
     samtools flagstat ${sampleName}.sorted.bam > ${sampleName}.flagstats.txt
     """
 }

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -84,7 +84,7 @@ process dehostBamFiles {
     """
     samtools index ${composite_bam}
     dehost_illumina.py --file ${composite_bam} \
-    --keep_id ${params.covid_ref_id} \
+    --keep_id ${params.keep_ref_id} \
     -q ${params.keep_min_map_quality} \
     -Q ${params.remove_min_map_quality} \
     -o ${sampleName}.dehosted.bam \

--- a/modules/nanopore_minimap2.nf
+++ b/modules/nanopore_minimap2.nf
@@ -80,7 +80,7 @@ process removeHumanReads {
 
     """
     samtools index $sorted_bam
-    dehost_nanopore.py --file $sorted_bam --min_reads ${params.min_read_count} --output ${sampleName}.host_removed.sorted.bam --revision ${rev}
+    dehost_nanopore.py --file $sorted_bam --min_reads ${params.min_read_count} --keep_id ${params.keep_ref_name} --output ${sampleName}.host_removed.sorted.bam --revision ${rev}
     """
 }
 

--- a/modules/nanopore_minimap2.nf
+++ b/modules/nanopore_minimap2.nf
@@ -80,7 +80,7 @@ process removeHumanReads {
 
     """
     samtools index $sorted_bam
-    dehost_nanopore.py --file $sorted_bam --min_reads ${params.min_read_count} --keep_id ${params.keep_ref_name} --output ${sampleName}.host_removed.sorted.bam --revision ${rev}
+    dehost_nanopore.py --file $sorted_bam --min_reads ${params.min_read_count} --keep_id ${params.keep_ref_id} --output ${sampleName}.host_removed.sorted.bam --revision ${rev}
     """
 }
 

--- a/modules/nanopore_minimap2.nf
+++ b/modules/nanopore_minimap2.nf
@@ -8,7 +8,7 @@ process generateMinimap2Index {
     path(viral_ref)
 
     output:
-    file("composite_ref.mmi"), emit: index
+    path("composite_ref.mmi"), emit: index
     path("*.process.yml"), emit: versions
 
     script:

--- a/modules/nanopore_minimap2.nf
+++ b/modules/nanopore_minimap2.nf
@@ -8,12 +8,19 @@ process generateMinimap2Index {
     path(viral_ref)
 
     output:
-    file "composite_ref.mmi"
+    file("composite_ref.mmi"), emit: index
+    path("*.process.yml"), emit: versions
 
     script:
     """
     cat $human_ref $viral_ref > composite_reference.fa
     minimap2 -d composite_ref.mmi composite_reference.fa
+
+    # Versions #
+    cat <<-END_VERSIONS > index.process.yml
+        "${task.process}":
+            minimap2: \$(echo \$(minimap2 --version))
+    END_VERSIONS
     """
 }
 
@@ -25,7 +32,8 @@ process fastqSizeSelection_MM2 {
     path(fastq)
 
     output:
-    tuple val(sampleName), path("${sampleName}_size_selected*.fastq")
+    tuple val(sampleName), path("${sampleName}_size_selected*.fastq"), emit: fastq
+    path("*.process.yml"), emit: versions
 
     script:
 
@@ -37,12 +45,24 @@ process fastqSizeSelection_MM2 {
     if ( fastq.isDirectory() ) {
         """
         artic guppyplex --min-length ${params.min_length} --max-length ${params.max_length} --prefix ${sampleName}_size_selected --directory $fastq
+
+        # Versions #
+        cat <<-END_VERSIONS > sizeselect.process.yml
+            "${task.process}":
+                artic: \$(echo \$(artic --version 2>&1) | sed 's/artic //')
+        END_VERSIONS
         """
     } else {
         """
         mkdir -p input_fastq
         mv $fastq input_fastq/
         artic guppyplex --min-length ${params.min_length} --max-length ${params.max_length} --prefix ${sampleName}_size_selected --directory input_fastq
+
+        # Versions #
+        cat <<-END_VERSIONS > sizeselect.process.yml
+            "${task.process}":
+                artic: \$(echo \$(artic --version 2>&1) | sed 's/artic //')
+        END_VERSIONS
         """
     }
 }
@@ -55,11 +75,19 @@ process compositeMappingMM2 {
     tuple val(sampleName), path(singular_fastq), path(composite_ref)
 
     output:
-    tuple val(sampleName), path("${sampleName}.sorted.bam")
+    tuple val(sampleName), path("${sampleName}.sorted.bam"), emit: comp_bam
+    path("*.process.yml"), emit: versions
 
     script:
     """
     minimap2 -ax map-ont $composite_ref $singular_fastq | samtools view -b | samtools sort -T "temp" -O BAM -o ${sampleName}.sorted.bam
+
+    # Versions #
+    cat <<-END_VERSIONS > composite.process.yml
+        "${task.process}":
+            minimap2: \$(echo \$(minimap2 --version))
+            samtools: \$(echo \$(samtools --version | head -n 1 | grep samtools | sed 's/samtools //'))
+    END_VERSIONS
     """
 }
 
@@ -73,6 +101,7 @@ process removeHumanReads {
     output:
     tuple val(sampleName), path("${sampleName}.host_removed.sorted.bam"), optional: true, emit: bam
     path "${sampleName}*.csv", emit: csv
+    path("*.process.yml"), emit: versions
 
     script:
 
@@ -81,6 +110,13 @@ process removeHumanReads {
     """
     samtools index $sorted_bam
     dehost_nanopore.py --file $sorted_bam --min_reads ${params.min_read_count} --keep_id ${params.keep_ref_id} --output ${sampleName}.host_removed.sorted.bam --revision ${rev}
+
+    # Versions #
+    cat <<-END_VERSIONS > dehostedbam.process.yml
+        "${task.process}":
+            samtools: \$(echo \$(samtools --version | head -n 1 | grep samtools | sed 's/samtools //'))
+            dehost_nanopore.py: 0.1.0
+    END_VERSIONS
     """
 }
 
@@ -94,11 +130,18 @@ process regenerateFastqFiles {
     tuple val(sampleName), path(dehosted_bam)
 
     output:
-    tuple val(sampleName), file("${sampleName}.host_removed.fastq")
+    tuple val(sampleName), file("${sampleName}.host_removed.fastq"), emit: dehosted_fastq
+    path("*.process.yml"), emit: versions
 
     script:
     """
     samtools fastq $dehosted_bam > ${sampleName}.host_removed.fastq
+
+    # Versions #
+    cat <<-END_VERSIONS > dehostedfastq.process.yml
+        "${task.process}":
+            samtools: \$(echo \$(samtools --version | head -n 1 | grep samtools | sed 's/samtools //'))
+    END_VERSIONS
     """
 }
 
@@ -112,11 +155,18 @@ process regenerateFastqFilesFlat {
     tuple val(sampleName), path(dehosted_bam)
 
     output:
-    tuple val(sampleName), file("${sampleName}.host_removed.fastq")
+    tuple val(sampleName), file("${sampleName}.host_removed.fastq"), emit: dehosted_fastq
+    path("*.process.yml"), emit: versions
 
     script:
     """
     samtools fastq $dehosted_bam > ${sampleName}.host_removed.fastq
+
+    # Versions #
+    cat <<-END_VERSIONS > dehostedfastq.process.yml
+        "${task.process}":
+            samtools: \$(echo \$(samtools --version | head -n 1 | grep samtools | sed 's/samtools //'))
+    END_VERSIONS
     """
 }
 
@@ -130,12 +180,20 @@ process regenerateFast5s_MM2 {
     tuple val(sampleName), path(dehosted_fastq_file), path(fast5_in)
 
     output:
-    path "fast5_pass/${sampleName}"
+    path "fast5_pass/${sampleName}", emit: dehosted_fast5
+    path("*.process.yml"), emit: versions
 
     script:
     """
     mkdir -p $sampleName
     mv $dehosted_fastq_file $sampleName/
     bash fast5-dehost-regenerate.sh $sampleName/ $sampleName $fast5_in ${task.cpus}
+
+    # Versions #
+    cat <<-END_VERSIONS > regeneratefast5.process.yml
+        "${task.process}":
+            awk: \$(echo \$(awk --version | head -n 1 | sed 's/GNU Awk //; s/,.*\$//'))
+            fast5_subset: NA
+    END_VERSIONS
     """
 }

--- a/modules/nanopore_minimap2.nf
+++ b/modules/nanopore_minimap2.nf
@@ -33,7 +33,7 @@ process fastqSizeSelection_MM2 {
     sampleName = fastq.getBaseName().replaceAll(~/\.fastq.*$/, '')
     
     // Fastq input can either be a directory or a set of fastq files
-    //  Outputs are the same then after
+    //  Outputs are the same then after allowing a hopefully streamlined pipeline
     if ( fastq.isDirectory() ) {
         """
         artic guppyplex --min-length ${params.min_length} --max-length ${params.max_length} --prefix ${sampleName}_size_selected --directory $fastq

--- a/modules/nanopore_minimap2.nf
+++ b/modules/nanopore_minimap2.nf
@@ -136,6 +136,6 @@ process regenerateFast5s_MM2 {
     """
     mkdir -p $sampleName
     mv $dehosted_fastq_file $sampleName/
-    bash fast5-dehost-regenerate.sh $sampleName/ $sampleName $fast5_in ${params.nanopore_threads}
+    bash fast5-dehost-regenerate.sh $sampleName/ $sampleName $fast5_in ${task.cpus}
     """
 }

--- a/modules/nanopore_nanostripper.nf
+++ b/modules/nanopore_nanostripper.nf
@@ -170,11 +170,18 @@ process combineCSVs {
     path(csvs)
 
     output:
-    path("removal_summary.csv")
+    path("removal_summary.csv"), emit: summary
+    path("*.process.yml"), emit: versions
 
     script:
     """
     csvtk concat *.csv > summary.csv
     csvtk sort -k1 summary.csv > removal_summary.csv
+
+    # Versions #
+    cat <<-END_VERSIONS > csv.process.yml
+        "${task.process}":
+            csvtk: \$(echo \$(csvtk version | sed 's/csvtk //'))
+    END_VERSIONS
     """
 }

--- a/modules/nanopore_nanostripper.nf
+++ b/modules/nanopore_nanostripper.nf
@@ -138,7 +138,7 @@ process regenerateFast5s_NS {
     def rev = workflow.commitId ?: workflow.revision ?: workflow.scriptId
 
     """
-    bash fast5-dehost-regenerate.sh $dehosted_fastq_barcode $barcodeName $fast5_dehosted ${params.nanopore_threads}
+    bash fast5-dehost-regenerate.sh $dehosted_fastq_barcode $barcodeName $fast5_dehosted ${task.cpus}
 
     bash generate-csv.sh ${barcodeName} ${fast5_dehosted}/${barcodeName}/nanostripper_summary.txt fast5_pass/${barcodeName}/filename_mapping.txt ${rev}
     """

--- a/modules/versions.nf
+++ b/modules/versions.nf
@@ -1,0 +1,36 @@
+process outputVersionsIllumina {
+    publishDir "${params.outdir}", pattern: "process_versions.yml", mode: "copy"
+
+    label 'smallCPU'
+
+    input:
+    path versions
+
+    output:
+    path "process_versions.yml"
+
+    script:
+    def rev = workflow.commitId ?: workflow.revision ?: workflow.scriptId
+    """
+    echo '"ncov-dehoster-${rev}":' > process_versions.yml
+    cat *.process.yml >> process_versions.yml
+    """
+}
+process outputVersionsNanopore {
+    publishDir "${params.outdir}/${params.run_name}", pattern: "process_versions.yml", mode: "copy"
+
+    label 'smallCPU'
+
+    input:
+    path versions
+
+    output:
+    path "process_versions.yml"
+
+    script:
+    def rev = workflow.commitId ?: workflow.revision ?: workflow.scriptId
+    """
+    echo '"ncov-dehoster-${rev}":' > process_versions.yml
+    cat *.process.yml >> process_versions.yml
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,7 +21,7 @@ params {
     // References - You will need to link your own human reference up with `--human_ref <reference>`
     human_ref = '/cvmfs/data.galaxyproject.org/byhand/hg38/seq/hg38.fa'
     cov2019_ref = "$baseDir/data/nCoV-2019.reference.fasta"
-    keep_ref_name = 'MN908947.3'
+    keep_ref_id = 'MN908947.3'
 
     // Extras
     tracedir = '${params.outdir}/pipeline_info'

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,6 +21,7 @@ params {
     // References - You will need to link your own human reference up with `--human_ref <reference>`
     human_ref = '/cvmfs/data.galaxyproject.org/byhand/hg38/seq/hg38.fa'
     cov2019_ref = "$baseDir/data/nCoV-2019.reference.fasta"
+    keep_ref_name = 'MN908947.3'
 
     // Extras
     tracedir = '${params.outdir}/pipeline_info'

--- a/workflows/illumina_dehosting.nf
+++ b/workflows/illumina_dehosting.nf
@@ -1,8 +1,4 @@
 // Illumina dehosting workflow
-
-// Enable dsl2
-nextflow.enable.dsl = 2
-
 // Import modules
 include {
   generateCompositeReference;
@@ -12,7 +8,7 @@ include {
   dehostBamFiles;
   generateDehostedReads;
   combineCSVs
-  } from '../modules/illumina.nf'
+} from '../modules/illumina.nf'
 
 // Workflow
 workflow illuminaDehosting {
@@ -23,17 +19,17 @@ workflow illuminaDehosting {
 
     main:
 
+    // Always need to make the composite reference, even if an index is given
+    // This might lead to issues if the composite index given does match the generated reference but we will watch for that and re-visit it later
     generateCompositeReference(ch_HumanReference, 
                                 ch_CovidReference)
 
     if ( params.composite_bwa_index ){
       grabCompositeIndex("${params.composite_bwa_index}")
-
       grabCompositeIndex.out
               .set{ ch_index }
     } else {
       indexCompositeReference(generateCompositeReference.out)
-
       indexCompositeReference.out.collect()
               .set{ ch_index }
     }

--- a/workflows/illumina_dehosting.nf
+++ b/workflows/illumina_dehosting.nf
@@ -10,6 +10,8 @@ include {
   combineCSVs
 } from '../modules/illumina.nf'
 
+include { outputVersionsIllumina } from '../modules/versions.nf'
+
 // Workflow
 workflow illuminaDehosting {
     take:
@@ -18,6 +20,9 @@ workflow illuminaDehosting {
       ch_CovidReference
 
     main:
+
+    // Setup tool version tracking - based on NF-Core's process
+    ch_versions = Channel.empty()
 
     // Always need to make the composite reference, even if an index is given
     // This might lead to issues if the composite index given does match the generated reference but we will watch for that and re-visit it later
@@ -30,8 +35,10 @@ workflow illuminaDehosting {
               .set{ ch_index }
     } else {
       indexCompositeReference(generateCompositeReference.out)
-      indexCompositeReference.out.collect()
+      indexCompositeReference.out.index.collect()
               .set{ ch_index }
+
+      ch_versions = ch_versions.mix(indexCompositeReference.out.versions)
     }
 
     compositeMappingBWA(ch_fastqs
@@ -43,4 +50,11 @@ workflow illuminaDehosting {
     generateDehostedReads(dehostBamFiles.out.bam)
 
     combineCSVs(dehostBamFiles.out.csv.collect())
+
+    // Version Tracking and Output
+    ch_versions = ch_versions.mix(compositeMappingBWA.out.versions.first())
+    ch_versions = ch_versions.mix(dehostBamFiles.out.versions.first())
+    ch_versions = ch_versions.mix(generateDehostedReads.out.versions.first())
+    ch_versions = ch_versions.mix(combineCSVs.out.versions)
+    outputVersionsIllumina(ch_versions.collect())
 }

--- a/workflows/nanopore_dehosting.nf
+++ b/workflows/nanopore_dehosting.nf
@@ -1,9 +1,16 @@
 /// Nanopore Dehosting Workflows
-
-// Enable dsl2
-nextflow.enable.dsl = 2
-
 // Import modules //
+// From minimap2 pipeline
+include {
+  generateMinimap2Index;
+  fastqSizeSelection_MM2;
+  compositeMappingMM2;
+  removeHumanReads;
+  regenerateFastqFiles;
+  regenerateFastqFilesFlat;
+  regenerateFast5s_MM2
+} from '../modules/nanopore_minimap2.nf'
+
 // From nanostripper pipeline
 include {
   nanostripper;
@@ -16,21 +23,62 @@ include {
   regenerateFast5s_NS;
   generateSimpleSequencingSummary;
   combineCSVs
-  } from '../modules/nanopore_nanostripper.nf'
+} from '../modules/nanopore_nanostripper.nf'
 
-// From minimap2 pipeline
-include {
-  generateMinimap2Index;
-  fastqSizeSelection_MM2;
-  compositeMappingMM2;
-  removeHumanReads;
-  regenerateFastqFiles;
-  regenerateFastqFilesFlat;
-  regenerateFast5s_MM2
-  } from '../modules/nanopore_minimap2.nf'
+// Workflow Minimap2 fastq files //
+workflow nanoporeMinimap2Dehosting {
+  take:
+      ch_fastq
+      ch_HumanReference
+      ch_CovidReference
+    
+    main:
+    // If given a reference utilize it, otherwise make it
+    if ( params.composite_minimap2_index ) {
+      Channel.fromPath("${params.composite_minimap2_index}")
+                        .set{ ch_CompReference }
+    } else {
+      generateMinimap2Index(ch_HumanReference, 
+                                ch_CovidReference)
+      generateMinimap2Index.out
+                           .set{ ch_CompReference }
+    }
+    
+    fastqSizeSelection_MM2(ch_fastq)
+    
+    compositeMappingMM2(fastqSizeSelection_MM2.out
+                                           .combine(ch_CompReference))
 
+    removeHumanReads(compositeMappingMM2.out)
 
-// Workflow Nanostripper //
+    // Output either flat fastq directory or normal nanopore formatted output based on CL --flat arg
+    if ( params.flat ) {
+      regenerateFastqFilesFlat(removeHumanReads.out.bam)
+      regenerateFastqFilesFlat.out
+                              .filter{ it[1].countFastq() >= params.min_read_count }
+                              .set { ch_host_rm_fastq }
+    } else {
+      regenerateFastqFiles(removeHumanReads.out.bam)
+      regenerateFastqFiles.out
+                          .filter{ it[1].countFastq() >= params.min_read_count }
+                          .set { ch_host_rm_fastq }
+    }
+
+    // If a fast5 directory is given, we can use the fastq files to regenerate dehosted fast5 files
+    // This process is slow without a lot of computational support behind it however; so its optional
+    if ( params.fast5_directory ) {
+      Channel.fromPath( "${params.fast5_directory}")
+                        .set{ ch_Fast5 }
+      regenerateFast5s_MM2(ch_host_rm_fastq.combine(ch_Fast5))
+
+      generateSimpleSequencingSummary(regenerateFast5s_MM2.out.collect())
+    }
+
+    // Finally make CSV output
+    combineCSVs(removeHumanReads.out.csv.collect())
+}
+
+// Workflow Nanostripper - NOT MAINTAINED AT THE MOMENT!!!//
 workflow nanoporeNanostripperDehosting {
     take:
       ch_fast5
@@ -69,7 +117,7 @@ workflow nanoporeNanostripperDehosting {
 
           guppyBasecallerGPU.out
                             .set{ ch_basecalled_fastqs }
-
+        // Guppy basecalling with CPU is insanely slow as a heads up so this will could take >12h
         } else {
           guppyBasecallerCPU(nanostripper.out.dehostedFast5)
 
@@ -94,57 +142,4 @@ workflow nanoporeNanostripperDehosting {
       } else {
         println('WARNING: dehosted fast5 files cannot be basecalled without a specified guppy environment, dehosting fast5 files only and then exiting')
       }
-}
-
-// Workflow Minimap2 fastq files //
-workflow nanoporeMinimap2Dehosting {
-  take:
-      ch_fastq
-      ch_HumanReference
-      ch_CovidReference
-    
-    main:
-    // If given a reference utilize it, otherwise make it
-    if ( params.composite_minimap2_index ) {
-      Channel.fromPath( "${params.composite_minimap2_index}")
-                        .set{ ch_CompReference }
-    } else {
-      generateMinimap2Index(ch_HumanReference, 
-                                ch_CovidReference)
-      generateMinimap2Index.out
-                           .set{ ch_CompReference }
-    }
-    
-    fastqSizeSelection_MM2(ch_fastq)
-    
-    compositeMappingMM2(fastqSizeSelection_MM2.out
-                                           .combine(ch_CompReference))
-
-    removeHumanReads(compositeMappingMM2.out)
-
-    // Output either flat fastq directory or normal in subdirectories based on cl input --flat
-    if ( params.flat ) {
-      regenerateFastqFilesFlat(removeHumanReads.out.bam)
-      regenerateFastqFilesFlat.out
-                              .filter{ it[1].countFastq() >= params.min_read_count }
-                              .set { ch_host_rm_fastq }
-    } else {
-      regenerateFastqFiles(removeHumanReads.out.bam)
-      regenerateFastqFiles.out
-                          .filter{ it[1].countFastq() >= params.min_read_count }
-                          .set { ch_host_rm_fastq }
-    }
-
-    // If a fast5 directory is given, we can use the fastq files to regenerate dehosted fast5 files
-    // This process is slow without a lot of computational support behind it however so its optional
-    if ( params.fast5_directory ) {
-      Channel.fromPath( "${params.fast5_directory}")
-                        .set{ ch_Fast5 }
-      regenerateFast5s_MM2(ch_host_rm_fastq.combine(ch_Fast5))
-
-      generateSimpleSequencingSummary(regenerateFast5s_MM2.out.collect())
-    }
-
-    // Finally make CSV output
-    combineCSVs(removeHumanReads.out.csv.collect())
 }


### PR DESCRIPTION
Currently, nanopore host removal is limited to using the Wuhan-1 header. Changes made here will allow any header line to be used

## User Relevant Changes
- New `--keep_ref_id <ID>` parameter to allow user to choose what the header is for the sequence they want to keep
    - Removed `--covid_ref_id <ID>` as an illumina specific argument and replaced with above so it all matches
- process_versions.yml now output
    - Shows the steps run and tools used with their versions

## Developer Relevant Changes
- Moved most of the minimap2 pipeline above the nanostripper pipeline
    - Will make it easier find the currently in use pipelines and we may remove/deactivate nanostripper pipeline going forwards
- More consistency in how workflows are formatted

## To Do
- [x] Fix up illumina and nanopore threads parameters found in the resources config (can be handled better with task cpus)
- [x] Add tool versions file
- [x] Remove redundancy in some mapping commands 
- [x] Update Changelog, Readme, and help command with important changes
    - Half done for all 3

## Won't do this time around/other suggestions for future
- More descriptive process names?
- Better input handling/checking