### PR TITLE
Fix inconsistent sorting issue

### DIFF
--- a/.github/scripts/run_illumina_pipeline.sh
+++ b/.github/scripts/run_illumina_pipeline.sh
@@ -168,9 +168,9 @@ fi
 
 # 2. Total Reads Kept
 READS=`awk -F, '$1 == "illumina-4_S12_dehosted" {print $4}' ./results/removal_summary.csv`
-if [[ "$READS" != "100" ]]; then 
+if [[ "$READS" != "1184" ]]; then 
     echo "Incorrect output: Number of Paired Reads Kept"
-    echo "  Expected: 100, Got: $READS"
+    echo "  Expected: 1184, Got: $READS"
     exit 1
 fi
 

--- a/.github/scripts/run_illumina_pipeline.sh
+++ b/.github/scripts/run_illumina_pipeline.sh
@@ -159,7 +159,7 @@ nextflow run ./main.nf \
 
 ### Check Pipeline Outputs ###
 # 1. Num Human Reads
-READS=`awk -F, '$1 == "illumina-18_S15" {print $2}' ./results/removal_summary.csv`
+READS=`awk -F, '$1 == "illumina-18_S15_dehosted" {print $2}' ./results/removal_summary.csv`
 if [[ "$READS" != "0" ]]; then 
     echo "Incorrect output: Number of Human Reads"
     echo "  Expected: 0, Got: $READS"
@@ -167,7 +167,7 @@ if [[ "$READS" != "0" ]]; then
 fi
 
 # 2. Total Reads Kept
-READS=`awk -F, '$1 == "illumina-4_S12" {print $4}' ./results/removal_summary.csv`
+READS=`awk -F, '$1 == "illumina-4_S12_dehosted" {print $4}' ./results/removal_summary.csv`
 if [[ "$READS" != "100" ]]; then 
     echo "Incorrect output: Number of Paired Reads Kept"
     echo "  Expected: 100, Got: $READS"
@@ -175,7 +175,7 @@ if [[ "$READS" != "100" ]]; then
 fi
 
 # Reset and Track
-mv .nextflow.log artifacts/illumina_downsampled.nextflow.log
+mv .nextflow.log artifacts/illumina_downsampled_reran.nextflow.log
 rm -rf results work/ .nextflow*
 
 echo "Done"

--- a/.github/scripts/run_illumina_pipeline.sh
+++ b/.github/scripts/run_illumina_pipeline.sh
@@ -6,6 +6,8 @@ mkdir -p conda_cache_dir
 
 # --------------------------------------------------------------------- #
 ### Run Illumina Pipeline ###
+echo "Illumina Pipeline Basic Test"
+echo "----------------------------"
 nextflow run ./main.nf \
     -profile mamba,test \
     --cache ./conda_cache_dir \
@@ -36,6 +38,8 @@ rm -rf results work/ .nextflow*
 
 # --------------------------------------------------------------------- #
 ### Run Illumina Pipeline with Downsampling ###
+echo "Illumina Pipeline Downsampling Fastqs"
+echo "-------------------------------------"
 nextflow run ./main.nf \
     -profile mamba,test \
     --cache ./conda_cache_dir \
@@ -85,6 +89,8 @@ rm -rf results work/ .nextflow*
 
 # --------------------------------------------------------------------- #
 ### Run Illumina Pipeline with Downsampling using Amplicons ###
+echo "Illumina Pipeline Downsampling Amplicons"
+echo "----------------------------------------"
 nextflow run ./main.nf \
     -profile mamba,test \
     --cache ./conda_cache_dir \
@@ -132,6 +138,39 @@ fi
 # 5. Region count file exists
 if [[ ! -f "./results/downsample_stats/illumina-4_S12_region_counts.csv" ]]; then
     echo "illumina-4_S12_region_counts.csv expected output file not found"
+    exit 1
+fi
+
+# Reset and Track
+mv .nextflow.log artifacts/illumina_downsampled.nextflow.log
+mv results next-round-input
+rm -rf work/ .nextflow*
+
+# --------------------------------------------------------------------- #
+### Run Illumina Pipeline on Previous Data to check it still maps ###
+echo "Illumina Pipeline Previous Data"
+echo "-------------------------------"
+nextflow run ./main.nf \
+    -profile mamba,test \
+    --cache ./conda_cache_dir \
+    --illumina \
+    --directory $PWD/next-round-input/dehosted_paired_fastqs \
+    --human_ref $PWD/.github/data/partial_hg38_ref.fa
+
+### Check Pipeline Outputs ###
+# 1. Num Human Reads
+READS=`awk -F, '$1 == "illumina-18_S15" {print $2}' ./results/removal_summary.csv`
+if [[ "$READS" != "0" ]]; then 
+    echo "Incorrect output: Number of Human Reads"
+    echo "  Expected: 0, Got: $READS"
+    exit 1
+fi
+
+# 2. Total Reads Kept
+READS=`awk -F, '$1 == "illumina-4_S12" {print $4}' ./results/removal_summary.csv`
+if [[ "$READS" != "100" ]]; then 
+    echo "Incorrect output: Number of Paired Reads Kept"
+    echo "  Expected: 100, Got: $READS"
     exit 1
 fi
 

--- a/bin/downsample_bam.sh
+++ b/bin/downsample_bam.sh
@@ -194,8 +194,6 @@ done < regions.txt
 
 # Merge
 samtools merge ${SAMPLE_NAME}_downsampled.bam *_downsampled.tmp.bam
-samtools sort ${SAMPLE_NAME}_downsampled.bam > ${SAMPLE_NAME}_downsampled.sorted.bam
-samtools index ${SAMPLE_NAME}_downsampled.sorted.bam
 
 # Remove unneeded files
 rm *.tmp.sam

--- a/environments/illumina.yml
+++ b/environments/illumina.yml
@@ -3,7 +3,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - samtools=1.17
+  - samtools=1.19
   - python=3.10
   - bwa
   - pysam=0.21.0

--- a/environments/illumina.yml
+++ b/environments/illumina.yml
@@ -3,7 +3,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - samtools=1.19
+  - samtools=1.17
   - python=3.10
   - bwa
   - pysam=0.21.0

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -67,10 +67,13 @@ process samtoolsAmpliconDownsample {
     # Get approximate per amplicon read count
     perAmpliconReadCount=\$((${sample_size}/\$(wc -l ${amplicons} | cut -f1 -d' ')))
 
-    # Run
-    samtools index ${bam}
+    # Files must be sorted to work with downsampling
+    samtools sort ${bam} > ${sampleName}.sorted.bam
+    samtools index ${sampleName}.sorted.bam
+
+    # Downsample with samtools view and awk
     bash downsample_bam.sh \\
-        --bam ${bam} \\
+        --bam ${sampleName}.sorted.bam \\
         -a ${amplicons} \\
         -p ${platform} \\
         --read-count \$perAmpliconReadCount \\

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -113,7 +113,9 @@ process dehostBamFiles {
         -Q ${params.remove_min_map_quality} \\
         -o ${sampleName}.dehosted.bam \\
         -R ${rev}
-    samtools sort -n ${sampleName}.dehosted.bam > ${sampleName}.dehosted.sorted.bam
+
+    # Sort final output
+    samtools sort -N ${sampleName}.dehosted.bam > ${sampleName}.dehosted.sorted.bam
 
     # Versions #
     cat <<-END_VERSIONS > versions.yml

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -85,7 +85,7 @@ process dehostBamFiles {
     tuple val(sampleName), path(composite_bam)
 
     output:
-    tuple val(sampleName), path("${sampleName}.dehosted.sorted.bam"), emit: bam
+    tuple val(sampleName), path("${sampleName}.dehosted.bam"), emit: bam
     path("${sampleName}*.csv"), emit: csv
     path("versions.yml"), emit: versions
 

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -113,7 +113,7 @@ process dehostBamFiles {
         -Q ${params.remove_min_map_quality} \\
         -o ${sampleName}.dehosted.bam \\
         -R ${rev}
-    samtools sort ${sampleName}.dehosted.bam > ${sampleName}.dehosted.sorted.bam
+    samtools sort -n ${sampleName}.dehosted.bam > ${sampleName}.dehosted.sorted.bam
 
     # Versions #
     cat <<-END_VERSIONS > versions.yml

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -13,7 +13,6 @@ process generateCompositeReference {
     cat $human_ref $viral_ref > composite_reference.fa
     """
 }
-
 process grabCompositeIndex {
     label 'process_single'
 
@@ -28,7 +27,6 @@ process grabCompositeIndex {
     ln -sf $index_folder/*.fa* ./
     """
 }
-
 process indexCompositeReference {
     publishDir "${params.outdir}/humanBWAIndex", pattern: "*.fa*", mode: "symlink"
     label 'process_high_memory'
@@ -51,7 +49,6 @@ process indexCompositeReference {
     END_VERSIONS
     """
 }
-
 process compositeMappingBWA {
     publishDir "${params.outdir}/compositeMAPs", pattern: "${sampleName}.*", mode: "copy"
     label 'process_medium'
@@ -80,9 +77,7 @@ process compositeMappingBWA {
     END_VERSIONS
     """
 }
-
 process dehostBamFiles {
-    publishDir "${params.outdir}/dehostedBAMs", pattern: "${sampleName}.dehosted.sorted.bam", mode: "copy"
     label 'process_low'
     tag { sampleName }
 
@@ -114,9 +109,6 @@ process dehostBamFiles {
         -o ${sampleName}.dehosted.bam \\
         -R ${rev}
 
-    # Sort final output
-    samtools sort -N ${sampleName}.dehosted.bam > ${sampleName}.dehosted.sorted.bam
-
     # Versions #
     cat <<-END_VERSIONS > versions.yml
         "${task.process}":
@@ -125,7 +117,30 @@ process dehostBamFiles {
     END_VERSIONS
     """
 }
+process samtoolsReadNameSort {
+    // Sort final bam file by read names to hopefully always have reads correctly paired
+    label 'process_low'
+    tag { sampleName }
+    publishDir "${params.outdir}/dehostedBAMs", pattern: "${sampleName}.dehosted.sorted.bam", mode: "copy"
 
+    input:
+    tuple val(sampleName), path(bam)
+
+    output:
+    tuple val(sampleName), path("${sampleName}.dehosted.sorted.bam"), emit: bam
+    path("versions.yml"), emit: versions
+
+    script:
+    """
+    samtools sort -n $bam > ${sampleName}.dehosted.sorted.bam
+
+    # Versions #
+    cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            samtools: \$(echo \$(samtools --version | head -n 1 | grep samtools | sed 's/samtools //'))
+    END_VERSIONS
+    """
+}
 process generateDehostedReads {
     // Output if we are not fastq downsampling
     if ( !params.downsample || params.downsample_amplicons ) {
@@ -152,7 +167,6 @@ process generateDehostedReads {
     END_VERSIONS
     """
 }
-
 process combineCSVs {
     publishDir "${params.outdir}", pattern: "removal_summary.csv", mode: "copy"
     label 'process_low'

--- a/nextflow.config
+++ b/nextflow.config
@@ -106,7 +106,7 @@ manifest {
     description = 'Removal of human reads from SARS-CoV-2 fastq and fast5 files'
     mainScript = 'main.nf'
     nextflowVersion = '>=21.04.0'
-    version = '0.5.0'
+    version = '0.5.1'
 }
 
 // Function to ensure that resource requirements don't go beyond


### PR DESCRIPTION
Inconsistent illumina sorting issue with read-ids not matching seems to have popped up for some samples

Adding in `-n` appears to fix it but also breaks downsampling so will likely add another step